### PR TITLE
Hotfix - PSPageControlDelegate name convention

### DIFF
--- a/Example/PSPageControl/ViewController.swift
+++ b/Example/PSPageControl/ViewController.swift
@@ -70,7 +70,7 @@ class ViewController: UIViewController {
 }
 
 // MARK: Protocol to get PSPageControl current index
-extension ViewController: PSPageControlProtocol {
+extension ViewController: PSPageControlDelegate {
     func didChange(index: Int) {
         print("PSPageControl - Current Index: \(index)")
     }

--- a/Example/PSPageControl/ViewController.swift
+++ b/Example/PSPageControl/ViewController.swift
@@ -9,6 +9,7 @@
 import UIKit
 import PSPageControl
 
+
 class ViewController: UIViewController {
     
     @IBOutlet weak var pageControl: PSPageControl!
@@ -19,6 +20,9 @@ class ViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        
+        // Delegate PageControl
+        pageControl.delegate = self
         
         let loremIpsum = ["Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin nibh augue, suscipit a, scelerisque sed, lacinia in, mi. Cras vel lorem. Etiam pellentesque aliquet tellus. Phasellus pharetra nulla ac diam. Quisque semper justo at risus.",
                           "Donec venenatis, turpis vel hendrerit interdum, dui ligula ultricies purus, sed posuere libero dui id orci.",
@@ -62,5 +66,12 @@ class ViewController: UIViewController {
         }
         
         pageControl.views = views
+    }
+}
+
+// MARK: Protocol to get PSPageControl current index
+extension ViewController: PSPageControlProtocol {
+    func didChange(index: Int) {
+        print("PSPageControl - Current Index: \(index)")
     }
 }

--- a/PSPageControl.swift
+++ b/PSPageControl.swift
@@ -10,6 +10,13 @@ import AVFoundation
 import UIKit
 import UIImageViewAlignedSwift
 
+/**
+ Event to detect when PSPageControl was changed
+ */
+public protocol PSPageControlProtocol {
+    func didChange(index: Int)
+}
+
 open class PSPageControl: UIView {
     
     /**
@@ -100,8 +107,20 @@ open class PSPageControl: UIView {
     fileprivate var background = UIImageViewAligned()
     fileprivate var pageControl = UIPageControl()
     fileprivate var touchPosition: CGPoint?
-    fileprivate var currentViewIndex = 0
     fileprivate var backgroundLayerFrameOrigin: CGPoint?
+    
+    /// Delegate to detect when current PSPageControl changed
+    open var delegate: PSPageControlProtocol?
+
+    /**
+         Get current PSPageViewControl
+     */
+    open var currentViewIndex = 0 {
+        didSet {
+            delegate?.didChange(index: currentViewIndex)
+        }
+    }
+    
     
     fileprivate func setup() {
         // Background image

--- a/PSPageControl.swift
+++ b/PSPageControl.swift
@@ -13,7 +13,7 @@ import UIImageViewAlignedSwift
 /**
  Event to detect when PSPageControl was changed
  */
-public protocol PSPageControlProtocol {
+public protocol PSPageControlDelegate: class {
     func didChange(index: Int)
 }
 
@@ -110,7 +110,7 @@ open class PSPageControl: UIView {
     fileprivate var backgroundLayerFrameOrigin: CGPoint?
     
     /// Delegate to detect when current PSPageControl changed
-    open var delegate: PSPageControlProtocol?
+    open weak var delegate: PSPageControlDelegate?
 
     /**
          Get current PSPageViewControl


### PR DESCRIPTION
Changes:
- Name of protocol PSPageControlProtocol is PSPageControlDelegate now
- PSPageControlDelegate variable delegate now is a weak variable